### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ Limitations:
          ```batch
          git clone https://github.com/vegardit/scoop-portable C:\apps\scoop-portable
          ```
-1. (Optional) Customize the installation by creating a file called `scoop-portable-config.cmd` in the same directory.
+2. (Optional) Customize the installation by creating a file called `scoop-portable-config.cmd` in the same directory.
     See [scoop-portable-config.example.cmd](scoop-portable-config.example.cmd) as an example.
-1. Now execute `scoop-portable.cmd`.
+3. Make sure the line break type is set to Windows (CR LF) via programs such as Notepad++ to prevent errors such as `The syntax of the command is incorrect`.
+4. Now execute `scoop-portable.cmd`.
    - On the first execution, scoop and the selected packages will be installed in a `scoop` sub-directory and the scoop environment is initialized.
 
 ![install](docs/img/install.png)


### PR DESCRIPTION
*Issue #, if available:*
#1

*Description of changes:*
I had a similar error of #1 while trying to update scoop, saying `The syntax of the command is incorrect`. I try to debug it by adding some echo printouts aroung the file and returned `< was unexpected at this time`, which is the same as #1. And then I see the problem, for some reason, saving it from raw returns Unix (LF) line break type and not Windows (CR LF) line break type, setting line break type to that fixes it and the error does not happen anymore.

Updated installation instructions to reflect that and should prevent those errors from happening for new users.
